### PR TITLE
feat : layered Architecture CRUD 완성

### DIFF
--- a/src/main/java/com/example/board/controller/BoardController.java
+++ b/src/main/java/com/example/board/controller/BoardController.java
@@ -1,0 +1,63 @@
+package com.example.board.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.board.dto.AllBoardResponse;
+import com.example.board.dto.BoardCreateRequestDto;
+import com.example.board.dto.BoardDetail;
+import com.example.board.dto.UpdateBoardRequestDto;
+import com.example.board.service.BoardService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/boards")
+@RequiredArgsConstructor
+public class BoardController {
+
+	private final BoardService boardService;
+
+	@GetMapping
+	@Operation(summary = "게시글 전체 조회", description = "게시글 전체 목록 조회")
+	public AllBoardResponse getBoards() {
+		return boardService.getAllBoards();
+	}
+
+	@GetMapping("/{id}")
+	@Operation(summary = "게시글 상세 조회", description = "게시글 상세 조회")
+	public ResponseEntity<BoardDetail> getBoardById(
+		@PathVariable @Schema(description = "조회할 게시글 id", example = "1") Long id) {
+		return ResponseEntity.ok(boardService.getBoardById(id));
+	}
+
+	@PostMapping
+	@Operation(summary = "게시글 작성 API", description = "게시글을 작성합니다.")
+	public ResponseEntity<BoardDetail> createBoard(@RequestBody BoardCreateRequestDto newBoard) {
+		return ResponseEntity.ok(boardService.createBoard(newBoard));
+	}
+
+	@PatchMapping("/{id}")
+	@Operation(summary = "게시글 수정", description = "id에 해당하는 게시글을 수정합니다.")
+	public ResponseEntity<BoardDetail> updateBoard(
+		@PathVariable @Schema(description = "수정할 게시글 id", example = "1") Long id,
+		@RequestBody UpdateBoardRequestDto updateData) {
+		return ResponseEntity.ok(boardService.updateBoard(id, updateData));
+	}
+
+	@DeleteMapping("/{id}")
+	@Operation(summary = "게시글 삭제", description = "id에 해당하는 게시글을 삭제합니다.")
+	public ResponseEntity<Void> deleteBoard(@PathVariable @Schema(description = "삭제할 게시글 id", example = "1") Long id) {
+		boardService.deleteBoard(id);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/example/board/dto/AllBoardResponse.java
+++ b/src/main/java/com/example/board/dto/AllBoardResponse.java
@@ -1,0 +1,16 @@
+package com.example.board.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record AllBoardResponse(
+	List<BoardDetail> boardDetailList
+) {
+	public static AllBoardResponse from(List<BoardDetail> boardDetailList) {
+		return AllBoardResponse.builder()
+			.boardDetailList(boardDetailList)
+			.build();
+	}
+}

--- a/src/main/java/com/example/board/dto/BoardCreateRequestDto.java
+++ b/src/main/java/com/example/board/dto/BoardCreateRequestDto.java
@@ -1,0 +1,15 @@
+package com.example.board.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record BoardCreateRequestDto(
+	@Schema(description = "작성할 게시글 제목", example = "제목입니다.")
+	String title,
+	@Schema(description = "작성할 게시글 내용", example = "내용입니다.")
+	String content,
+	@Schema(description = "작성자 이름", example = "홍길동")
+	String author
+) {
+}

--- a/src/main/java/com/example/board/dto/BoardDetail.java
+++ b/src/main/java/com/example/board/dto/BoardDetail.java
@@ -2,13 +2,18 @@ package com.example.board.dto;
 
 import com.example.board.entity.Board;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record BoardDetail(
+	@Schema(description = "게시글 Id", example = "1")
 	Long id,
+	@Schema(description = "게시글 제목", example = "제목입니다.")
 	String title,
+	@Schema(description = "게시글 내용", example = "내용입니다.")
 	String content,
+	@Schema(description = "게시글 작성자", example = "홍길동")
 	String author
 ) {
 	public static BoardDetail from(Board board) {

--- a/src/main/java/com/example/board/dto/BoardDetail.java
+++ b/src/main/java/com/example/board/dto/BoardDetail.java
@@ -1,0 +1,22 @@
+package com.example.board.dto;
+
+import com.example.board.entity.Board;
+
+import lombok.Builder;
+
+@Builder
+public record BoardDetail(
+	Long id,
+	String title,
+	String content,
+	String author
+) {
+	public static BoardDetail from(Board board) {
+		return BoardDetail.builder()
+			.id(board.getId())
+			.title(board.getTitle())
+			.content(board.getContent())
+			.author(board.getAuthor())
+			.build();
+	}
+}

--- a/src/main/java/com/example/board/dto/UpdateBoardRequestDto.java
+++ b/src/main/java/com/example/board/dto/UpdateBoardRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.board.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UpdateBoardRequestDto(
+	@Schema(description = "업데이트 할 게시글 제목", example = "변경된 제목")
+	String title,
+	@Schema(description = "업데이트 할 게시글 내용", example = "변경된 내용")
+	String content
+) {
+}

--- a/src/main/java/com/example/board/entity/Board.java
+++ b/src/main/java/com/example/board/entity/Board.java
@@ -1,0 +1,45 @@
+package com.example.board.entity;
+
+import com.example.board.dto.BoardCreateRequestDto;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Board {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String title;
+
+	private String content;
+
+	private String author;
+
+	public static Board from(BoardCreateRequestDto dto) {
+		return Board.builder()
+			.author(dto.author())
+			.title(dto.title())
+			.content(dto.content())
+			.build();
+	}
+
+	public void updateTitle(String title) {
+		this.title = title;
+	}
+
+	public void updateContent(String content) {
+		this.content = content;
+	}
+}

--- a/src/main/java/com/example/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/board/repository/BoardRepository.java
@@ -1,0 +1,8 @@
+package com.example.board.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.board.entity.Board;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/src/main/java/com/example/board/service/BoardService.java
+++ b/src/main/java/com/example/board/service/BoardService.java
@@ -1,0 +1,65 @@
+package com.example.board.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.example.board.dto.AllBoardResponse;
+import com.example.board.dto.BoardCreateRequestDto;
+import com.example.board.dto.BoardDetail;
+import com.example.board.dto.UpdateBoardRequestDto;
+import com.example.board.entity.Board;
+import com.example.board.repository.BoardRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BoardService {
+	private final BoardRepository boardRepository;
+
+	public AllBoardResponse getAllBoards() {
+		List<Board> allBoard = boardRepository.findAll();
+		return AllBoardResponse.from(allBoard.stream()
+			.map(BoardDetail::from)
+			.toList());
+	}
+
+	public BoardDetail getBoardById(Long id) {
+		return BoardDetail.from(findBoardById(id));
+	}
+
+	@Transactional
+	public BoardDetail createBoard(BoardCreateRequestDto dto) {
+		return BoardDetail.from(boardRepository.save(Board.from(dto)));
+	}
+
+	@Transactional
+	public BoardDetail updateBoard(Long boardId, UpdateBoardRequestDto boardData) {
+		Board board = findBoardById(boardId);
+
+		if (StringUtils.hasText(boardData.content())) {
+			board.updateContent(boardData.content());
+		}
+
+		if(StringUtils.hasText(boardData.title())) {
+			board.updateTitle(boardData.title());
+		}
+
+		return BoardDetail.from(boardRepository.save(board));
+	}
+
+	@Transactional
+	public void deleteBoard(Long id) {
+		boardRepository.deleteById(id);
+	}
+
+
+	private Board findBoardById(Long id) {
+		return boardRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("Board not found"));
+	}
+}


### PR DESCRIPTION
기본 구조인 Layered Architecture CRUD 간단하게 완성

## 엔티티 구조
```bash
📦 com.example.layeredarchitecture.board
├── controller
│   └── BoardController.java    # REST 컨트롤러
├── service
│   └── BoardService.java       # 서비스 클래스 (비즈니스 로직)
├── repository
│   └── BoardRepository.java    # JPA 리포지토리 인터페이스
└── entity
    └── Board.java              # 엔티티
└── dto
    └── AllBoardResponse.java     # 게시글 전체 응답 Dto
    └── BoardCreateRequestDto.java     # 게시글 작성 요청 Dto
    └── BoardDetail.java     # 게시글 상세 응답 Dto
    └── UpdateBoardRequestDto.java     # 게시글 수정 요청 Dto
```

## Layerd Architecture 도식화
![image](https://github.com/user-attachments/assets/14b6de1a-e858-4008-aa6b-1051ac36f6e6)


## 비고
- 페이징, 사용자 인증 등 제외한 간단한 기능만 구현
- 모든 계층이 내부적으로 Spring Framework 및 JPA 등에 직접 의존하고있음
  - Service는 BoardRepository (Spring Data JPA 인터페이스) 직접 사용
  - Board 엔티티 JPA에 종속적
  - 테스트를 위해 외부 의존성을 모킹 해야 할 경우 유연성이 떨어질 수 있음