### PR TITLE
Hexagonal 도입

### DIFF
--- a/src/main/java/com/example/hexagonal/board/adapters/in/web/controller/BoardControllerHexagonal.java
+++ b/src/main/java/com/example/hexagonal/board/adapters/in/web/controller/BoardControllerHexagonal.java
@@ -1,0 +1,77 @@
+package com.example.hexagonal.board.adapters.in.web.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.hexagonal.board.adapters.in.web.dto.AllBoardResponse;
+import com.example.hexagonal.board.adapters.in.web.dto.BoardCreateRequestDto;
+import com.example.hexagonal.board.adapters.in.web.dto.BoardDetail;
+import com.example.hexagonal.board.adapters.in.web.dto.UpdateBoardRequestDto;
+import com.example.hexagonal.board.adapters.in.web.mapper.BoardRequestMapper;
+import com.example.hexagonal.board.adapters.in.web.mapper.BoardResponseMapper;
+import com.example.hexagonal.board.domain.Board;
+import com.example.hexagonal.board.domain.BoardService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/hexagonal/boards")
+@RequiredArgsConstructor
+@Tag(name = "BoardControllerHexagonal", description = "헥사고날 게시판 컨트롤러")
+public class BoardControllerHexagonal {
+
+	private final BoardService service;
+	private final BoardRequestMapper requestMapper;
+	private final BoardResponseMapper responseMapper;
+
+	@GetMapping
+	@Operation(summary = "게시글 전체 조회", description = "게시글 전체 목록 조회")
+	public ResponseEntity<AllBoardResponse> getAll() {
+		List<Board> boards = service.getAllBoards();
+		return ResponseEntity.ok(responseMapper.toAllDto(boards));
+	}
+
+	@GetMapping("/{id}")
+	@Operation(summary = "게시글 상세 조회", description = "게시글 상세 조회")
+	public ResponseEntity<BoardDetail> getOne(
+		@PathVariable @Schema(description = "조회할 게시글 id", example = "1") Long id) {
+		Board board = service.getBoard(id);
+		return ResponseEntity.ok(responseMapper.toResponseDto(board));
+	}
+
+	@PostMapping
+	@Operation(summary = "게시글 작성 API", description = "게시글을 작성합니다.")
+	public ResponseEntity<BoardDetail> create(@RequestBody BoardCreateRequestDto createRequestDto) {
+		Board domain = requestMapper.toDomainForCreate(createRequestDto);
+		Board createdDomainBoardEntity = service.createBoard(domain);
+		return ResponseEntity.ok(responseMapper.toResponseDto(createdDomainBoardEntity));
+	}
+
+	@PatchMapping("/{id}")
+	@Operation(summary = "게시글 수정", description = "id에 해당하는 게시글을 수정합니다.")
+	public ResponseEntity<BoardDetail> update(@PathVariable @Schema(description = "수정할 게시글 id", example = "1") Long id,
+		@RequestBody UpdateBoardRequestDto updateRequestDto) {
+		Board domainForUpdate = requestMapper.toDomainForUpdate(updateRequestDto);
+		Board updatedDomain = service.updateBoard(id, domainForUpdate);
+		return ResponseEntity.ok(responseMapper.toResponseDto(updatedDomain));
+	}
+
+	@DeleteMapping("/{id}")
+	@Operation(summary = "게시글 삭제", description = "id에 해당하는 게시글을 삭제합니다.")
+	public ResponseEntity<Void> delete(@PathVariable @Schema(description = "삭제할 게시글 id", example = "1") Long id) {
+		service.deleteBoard(id);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/example/hexagonal/board/adapters/in/web/dto/AllBoardResponse.java
+++ b/src/main/java/com/example/hexagonal/board/adapters/in/web/dto/AllBoardResponse.java
@@ -1,0 +1,18 @@
+package com.example.hexagonal.board.adapters.in.web.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record AllBoardResponse(
+	@Schema(description = "게시글 정보 목록")
+	List<BoardDetail> boardDetailList
+) {
+	public static AllBoardResponse from(List<BoardDetail> boardDetailList) {
+		return AllBoardResponse.builder()
+			.boardDetailList(boardDetailList)
+			.build();
+	}
+}

--- a/src/main/java/com/example/hexagonal/board/adapters/in/web/dto/BoardCreateRequestDto.java
+++ b/src/main/java/com/example/hexagonal/board/adapters/in/web/dto/BoardCreateRequestDto.java
@@ -1,0 +1,15 @@
+package com.example.hexagonal.board.adapters.in.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record BoardCreateRequestDto(
+	@Schema(description = "작성할 게시글 제목", example = "제목입니다.")
+	String title,
+	@Schema(description = "작성할 게시글 내용", example = "내용입니다.")
+	String content,
+	@Schema(description = "작성자 이름", example = "홍길동")
+	String author
+) {
+}

--- a/src/main/java/com/example/hexagonal/board/adapters/in/web/dto/BoardDetail.java
+++ b/src/main/java/com/example/hexagonal/board/adapters/in/web/dto/BoardDetail.java
@@ -1,0 +1,27 @@
+package com.example.hexagonal.board.adapters.in.web.dto;
+
+import com.example.hexagonal.board.domain.Board;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record BoardDetail(
+	@Schema(description = "게시글 Id", example = "1")
+	Long id,
+	@Schema(description = "게시글 제목", example = "제목입니다.")
+	String title,
+	@Schema(description = "게시글 내용", example = "내용입니다.")
+	String content,
+	@Schema(description = "게시글 작성자", example = "홍길동")
+	String author
+) {
+	public static BoardDetail from(Board board) {
+		return BoardDetail.builder()
+			.id(board.getId())
+			.title(board.getTitle())
+			.content(board.getContent())
+			.author(board.getAuthor())
+			.build();
+	}
+}

--- a/src/main/java/com/example/hexagonal/board/adapters/in/web/dto/UpdateBoardRequestDto.java
+++ b/src/main/java/com/example/hexagonal/board/adapters/in/web/dto/UpdateBoardRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.hexagonal.board.adapters.in.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UpdateBoardRequestDto(
+	@Schema(description = "업데이트 할 게시글 제목", example = "변경된 제목")
+	String title,
+	@Schema(description = "업데이트 할 게시글 내용", example = "변경된 내용")
+	String content
+) {
+}

--- a/src/main/java/com/example/hexagonal/board/adapters/in/web/mapper/BoardRequestMapper.java
+++ b/src/main/java/com/example/hexagonal/board/adapters/in/web/mapper/BoardRequestMapper.java
@@ -1,0 +1,23 @@
+package com.example.hexagonal.board.adapters.in.web.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.example.hexagonal.board.adapters.in.web.dto.BoardCreateRequestDto;
+import com.example.hexagonal.board.adapters.in.web.dto.UpdateBoardRequestDto;
+import com.example.hexagonal.board.domain.Board;
+
+@Component
+public class BoardRequestMapper {
+
+	// domain entity가 dto 존재 모르게 값 꺼내서 할당해야 함
+	public Board toDomainForCreate(BoardCreateRequestDto dto) {
+		// id는 아직 모르니 null
+		return Board.of(null, dto.title(), dto.content(), dto.author());
+	}
+
+	// domain entity가 dto 존재 모르게 값 꺼내서 할당해야 함
+	public Board toDomainForUpdate(UpdateBoardRequestDto dto) {
+		// id는 아직 모르니 null
+		return Board.of(null, dto.title(), dto.content(), null);
+	}
+}

--- a/src/main/java/com/example/hexagonal/board/adapters/in/web/mapper/BoardResponseMapper.java
+++ b/src/main/java/com/example/hexagonal/board/adapters/in/web/mapper/BoardResponseMapper.java
@@ -1,0 +1,31 @@
+package com.example.hexagonal.board.adapters.in.web.mapper;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.example.hexagonal.board.adapters.in.web.dto.AllBoardResponse;
+import com.example.hexagonal.board.adapters.in.web.dto.BoardDetail;
+import com.example.hexagonal.board.domain.Board;
+
+@Component
+public class BoardResponseMapper {
+
+	/**
+	 * 단건 Dto 목록을 Dto로 감쌈 - 의존성 도메인쪽으로 의존이라 가능
+	 */
+	public AllBoardResponse toAllDto(List<Board> boards) {
+		List<BoardDetail> list = boards.stream()
+			.map(BoardDetail::from)
+			.toList();
+
+		return AllBoardResponse.from(list);
+	}
+
+	/**
+	 * 단건 Dto 변환 - 의존성 도메인쪽으로 의존이라 가능
+	 */
+	public BoardDetail toResponseDto(Board board) {
+		return BoardDetail.from(board);
+	}
+}

--- a/src/main/java/com/example/hexagonal/board/adapters/out/persistence/BoardRepositoryAdapter.java
+++ b/src/main/java/com/example/hexagonal/board/adapters/out/persistence/BoardRepositoryAdapter.java
@@ -1,0 +1,45 @@
+package com.example.hexagonal.board.adapters.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+
+import com.example.hexagonal.board.adapters.out.persistence.entity.BoardEntity;
+import com.example.hexagonal.board.domain.Board;
+import com.example.hexagonal.board.domain.BoardRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BoardRepositoryAdapter implements BoardRepository {
+
+	private final SpringDataBoardRepository jpa;
+
+	@Override
+	public List<Board> findAll() {
+		return jpa.findAll().stream()
+			.map(BoardEntity::toDomain)
+			.toList();
+	}
+
+	@Override
+	public Optional<Board> findById(Long id) {
+		return jpa.findById(id)
+			.map(BoardEntity::toDomain);
+	}
+
+	@Override
+	public Board save(Board b) {
+		BoardEntity entity = BoardEntity.fromDomain(b);
+		BoardEntity saved = jpa.save(entity);
+		return saved.toDomain();
+	}
+
+	@Override
+	public void deleteById(Long id) {
+		jpa.deleteById(id);
+	}
+}

--- a/src/main/java/com/example/hexagonal/board/adapters/out/persistence/SpringDataBoardRepository.java
+++ b/src/main/java/com/example/hexagonal/board/adapters/out/persistence/SpringDataBoardRepository.java
@@ -1,0 +1,8 @@
+package com.example.hexagonal.board.adapters.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.hexagonal.board.adapters.out.persistence.entity.BoardEntity;
+
+public interface SpringDataBoardRepository extends JpaRepository<BoardEntity, Long> {
+}

--- a/src/main/java/com/example/hexagonal/board/adapters/out/persistence/entity/BoardEntity.java
+++ b/src/main/java/com/example/hexagonal/board/adapters/out/persistence/entity/BoardEntity.java
@@ -1,0 +1,52 @@
+package com.example.hexagonal.board.adapters.out.persistence.entity;
+
+import com.example.hexagonal.board.domain.Board;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "hexxagonal_board")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BoardEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String title;
+	private String content;
+	private String author;
+
+
+	// --- 도메인 객체로 변환 ---
+	public Board toDomain() {
+		return Board.of(id, title, content, author);
+	}
+
+	// --- 도메인 객체를 엔티티로 변환 ---
+	public static BoardEntity fromDomain(Board board) {
+		return new BoardEntity(
+			board.getId(),
+			board.getTitle(),
+			board.getContent(),
+			board.getAuthor()
+		);
+	}
+
+	public void updateTitle(String title) {
+		this.title = title;
+	}
+
+	public void updateContent(String content) {
+		this.content = content;
+	}
+
+}

--- a/src/main/java/com/example/hexagonal/board/application/BoardServiceImpl.java
+++ b/src/main/java/com/example/hexagonal/board/application/BoardServiceImpl.java
@@ -1,0 +1,52 @@
+package com.example.hexagonal.board.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.hexagonal.board.domain.Board;
+import com.example.hexagonal.board.domain.BoardRepository;
+import com.example.hexagonal.board.domain.BoardService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BoardServiceImpl implements BoardService {
+
+	private final BoardRepository repo;
+
+	@Override
+	public List<Board> getAllBoards() {
+		return repo.findAll();
+	}
+
+	@Override
+	public Board getBoard(Long id) {
+		return repo.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("Not found"));
+	}
+
+	@Override
+	@Transactional
+	public Board createBoard(Board board) {
+		return repo.save(board);
+	}
+
+	@Override
+	@Transactional
+	public Board updateBoard(Long id, Board board) {
+		Board exist = getBoard(id);
+		exist.updateContent(board.getContent());
+		exist.updateTitle(board.getTitle());
+		return repo.save(exist);
+	}
+
+	@Override
+	@Transactional
+	public void deleteBoard(Long id) {
+		repo.deleteById(id);
+	}
+}

--- a/src/main/java/com/example/hexagonal/board/domain/Board.java
+++ b/src/main/java/com/example/hexagonal/board/domain/Board.java
@@ -1,0 +1,46 @@
+package com.example.hexagonal.board.domain;
+
+public class Board {
+	private Long id;
+	private String title;
+	private String content;
+	private String author;
+
+	public Board() {
+	}
+
+	public Board(Long id, String title, String content, String author) {
+		this.id = id;
+		this.title = title;
+		this.content = content;
+		this.author = author;
+	}
+
+	public static Board of(Long id, String title, String content, String author) {
+		return new Board(id, title, content, author);
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public String getAuthor() {
+		return author;
+	}
+
+	public void updateTitle(String title) {
+		this.title = title;
+	}
+
+	public void updateContent(String content) {
+		this.content = content;
+	}
+}

--- a/src/main/java/com/example/hexagonal/board/domain/BoardRepository.java
+++ b/src/main/java/com/example/hexagonal/board/domain/BoardRepository.java
@@ -1,0 +1,11 @@
+package com.example.hexagonal.board.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BoardRepository {
+	List<Board> findAll();
+	Optional<Board> findById(Long id);
+	Board save(Board board);
+	void deleteById(Long id);
+}

--- a/src/main/java/com/example/hexagonal/board/domain/BoardService.java
+++ b/src/main/java/com/example/hexagonal/board/domain/BoardService.java
@@ -1,0 +1,11 @@
+package com.example.hexagonal.board.domain;
+
+import java.util.List;
+
+public interface BoardService {
+	List<Board> getAllBoards();
+	Board getBoard(Long id);
+	Board createBoard(Board board);
+	Board updateBoard(Long id, Board board);
+	void deleteBoard(Long id);
+}

--- a/src/main/java/com/example/layeredarchitecture/board/controller/BoardController.java
+++ b/src/main/java/com/example/layeredarchitecture/board/controller/BoardController.java
@@ -1,4 +1,4 @@
-package com.example.board.controller;
+package com.example.layeredarchitecture.board.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -10,11 +10,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.example.board.dto.AllBoardResponse;
-import com.example.board.dto.BoardCreateRequestDto;
-import com.example.board.dto.BoardDetail;
-import com.example.board.dto.UpdateBoardRequestDto;
-import com.example.board.service.BoardService;
+import com.example.layeredarchitecture.board.dto.AllBoardResponse;
+import com.example.layeredarchitecture.board.dto.BoardCreateRequestDto;
+import com.example.layeredarchitecture.board.dto.BoardDetail;
+import com.example.layeredarchitecture.board.dto.UpdateBoardRequestDto;
+import com.example.layeredarchitecture.board.service.BoardService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/example/layeredarchitecture/board/dto/AllBoardResponse.java
+++ b/src/main/java/com/example/layeredarchitecture/board/dto/AllBoardResponse.java
@@ -1,4 +1,4 @@
-package com.example.board.dto;
+package com.example.layeredarchitecture.board.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/example/layeredarchitecture/board/dto/BoardCreateRequestDto.java
+++ b/src/main/java/com/example/layeredarchitecture/board/dto/BoardCreateRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.board.dto;
+package com.example.layeredarchitecture.board.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;

--- a/src/main/java/com/example/layeredarchitecture/board/dto/BoardDetail.java
+++ b/src/main/java/com/example/layeredarchitecture/board/dto/BoardDetail.java
@@ -1,6 +1,6 @@
-package com.example.board.dto;
+package com.example.layeredarchitecture.board.dto;
 
-import com.example.board.entity.Board;
+import com.example.layeredarchitecture.board.entity.Board;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;

--- a/src/main/java/com/example/layeredarchitecture/board/dto/UpdateBoardRequestDto.java
+++ b/src/main/java/com/example/layeredarchitecture/board/dto/UpdateBoardRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.board.dto;
+package com.example.layeredarchitecture.board.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/example/layeredarchitecture/board/entity/Board.java
+++ b/src/main/java/com/example/layeredarchitecture/board/entity/Board.java
@@ -1,6 +1,6 @@
-package com.example.board.entity;
+package com.example.layeredarchitecture.board.entity;
 
-import com.example.board.dto.BoardCreateRequestDto;
+import com.example.layeredarchitecture.board.dto.BoardCreateRequestDto;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/example/layeredarchitecture/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/layeredarchitecture/board/repository/BoardRepository.java
@@ -1,8 +1,8 @@
-package com.example.board.repository;
+package com.example.layeredarchitecture.board.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.example.board.entity.Board;
+import com.example.layeredarchitecture.board.entity.Board;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 }

--- a/src/main/java/com/example/layeredarchitecture/board/service/BoardService.java
+++ b/src/main/java/com/example/layeredarchitecture/board/service/BoardService.java
@@ -1,4 +1,4 @@
-package com.example.board.service;
+package com.example.layeredarchitecture.board.service;
 
 import java.util.List;
 
@@ -6,12 +6,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import com.example.board.dto.AllBoardResponse;
-import com.example.board.dto.BoardCreateRequestDto;
-import com.example.board.dto.BoardDetail;
-import com.example.board.dto.UpdateBoardRequestDto;
-import com.example.board.entity.Board;
-import com.example.board.repository.BoardRepository;
+import com.example.layeredarchitecture.board.dto.AllBoardResponse;
+import com.example.layeredarchitecture.board.dto.BoardCreateRequestDto;
+import com.example.layeredarchitecture.board.dto.BoardDetail;
+import com.example.layeredarchitecture.board.dto.UpdateBoardRequestDto;
+import com.example.layeredarchitecture.board.entity.Board;
+import com.example.layeredarchitecture.board.repository.BoardRepository;
 
 import lombok.RequiredArgsConstructor;
 


### PR DESCRIPTION
## 패키지 구조

```bash
com.example.hexagonal.board
├── domain                             # Pure Domain (POJO + Port 인터페이스)
│   ├── Board.java                     # 순수 도메인 모델
│   ├── BoardService.java              # Use Case Port
│   └── BoardRepository.java           # Persistence Port
├── application                        # Use Case 구현체
│   └── BoardServiceImpl.java
└── adapters
    ├── in
    │   └── web
    │       ├── controller
    │       │   └── BoardController.java
    │       ├── dto
    │       │   ├── BoardCreateRequestDto.java
    │       │   ├── BoardDetailResponseDto.java
    │       │   └── AllBoardResponseDto.java
    │       └── mapper  # DTO <-> 순수 도메인 모델
    │           ├── BoardRequestMapper.java
    │           └── BoardResponseMapper.java
    └── out
        └── persistence
            ├── entity
            │   └── BoardEntity.java # JPA Entity
            ├── SpringDataBoardEntityRepository.java  # JPA Repository
            └── BoardRepositoryAdapter.java
```

## 이미지

![image](https://github.com/user-attachments/assets/7cd59462-b291-4503-aa62-9e918f6103c3)

## 용어

### Domain (비즈니스 코어)
- Board.java: 순수한 POJO(필드+비즈니스 규칙)
- BoardService, BoardRepository: 도메인이 외부와 소통할 계약(인터페이스)만 정의

### Application (유스케이스 구현)
- BoardServiceImpl: 계약(Use Case Port)을 구현, 트랜잭션·검증·순서(비즈니스 흐름) 관리

### Adapters (포트 구현체)
- in/web (클라이언트→도메인 방향)\
  - DTO : JSON 요청, 응답 스펙
  - Mapper: DTO ↔ 도메인 객체 변환
  - Controller: Mapper로 DTO를 도메인으로 바꿔서 Application Service 호출, 결과를 다시 DTO로 매핑해 응답

- out/persistence (도메인→DB 방향)
  - BoardEntity, SpringDataBoardEntityRepository (JPA)
  - BoardRepositoryAdapter: Persistence Port 구현체


## 왜 DTO/Mapper를 컨트롤러쪽에?
- API 스펙을 도메인 모델과 분리하여 유지보수·보안·버전 관리 용이
- 도메인 코어는 절대 DTO를 몰라야 순수성 유지

## Port를 어디에 둘 것인가?

### 도메인 패키지에 Port (현재 방식)
- 포트가 도메인 일부 -> 도메인 코어와 함께 버전 관리
- 가장 널리 사용되는 방식

### application/port 패키지 방식
- `application/port/in/...`, `application/port/out/...`
- 포트와 유스케이스 구현 사이를 분리하고 싶을 때 사용
- 중, 대형 프로젝트에서 `Application` 모듈을 더 명확히 구분

## Port in/out 구분
|구분|정의|예시 클래스|
|:----:|:-----:|:------------:|
|입력 포트|외부 요청(컨트롤러, CLI 등)을 도메인 유스케이스로 연결하는 인터페이스|`BoardService` (도메인의 Use Case 인터페이스)|
|출력 포트|도메인이 `저장, 조회, 메시징` 등 외부 기능 호출에 사용하는 인터페이스|`BoardRepository` (도메인의 Persistence 인터페이스)|

- **입력 포트**  : "클라이언트가 이 기능을 쓰려면 이 메서드를 호출하세요" 선언
- **출력 포트** : "도메인 로직이 이 외부 기능을 쓰려면 이 메서드를 호출하세요" 선언
